### PR TITLE
docs(README): update project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `generate-policy-bot.yml`
+# `generate-policy-bot-config`
 
 This script generates the [Policy Bot][policy-bot] configuration file.
 


### PR DESCRIPTION
This was split from an internal repo and `generate-policy.yml` was what it was called there. I thought this name was nicer for a public project.
