### PR TITLE
fix: remove rule properly

### DIFF
--- a/policy.yml
+++ b/policy.yml
@@ -5,7 +5,6 @@ policy:
     - or:
         - MERGE_WITH_GENERATED
         - override policies
-    - policy bot config is valid when modified
 
 approval_rules:
   - name: override policies


### PR DESCRIPTION
Oh the irony that I made the policy bot config invalid when temporarily dropping the validity check.
