### PR TITLE
chore(release): make releases with with github actions user

### DIFF
--- a/.release-please.json
+++ b/.release-please.json
@@ -50,7 +50,9 @@
       "type": "refactor"
     }
   ],
+  "draft": true,
   "draft-pull-request": true,
+  "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {
     ".": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ We use [`release-please`][release-please] to create releases. This will maintain
 a draft pull request with the changes needed to bump the version and update the
 changelog, updated with the changes since the last release.
 
-Releasing should be as simple as merging that pull request. Check that a GitHub
+Releasing should be as simple as undrafting and merging that pull request, then
+double-checking the created release and publishing it. Check that a GitHub
 release, a tag, and the Docker releases were created.
 
 ### Use conventional commit messages


### PR DESCRIPTION
Since the GitHub Actions user creates our release tag and release, it doesn't trigger the actual build. But we can do the same thing we do for the release PR: create the release in draft mode, and then a human publishes. Since a human takes that action, it should trigger the build.

Also, don't include the project name in the tag names. It's not required since this isn't a monorepo.
