### PR TITLE
chore(ci): replicate path filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ on:
       - opened
       - ready_for_review
       - synchronize
+    paths:
+      - go.mod
+      - go.sum
+      - "**/*.go"
+      - Dockerfile
+      - .github/workflows/build.yml
 
   push:
     branches:

--- a/.policy.yml
+++ b/.policy.yml
@@ -14,6 +14,14 @@ policy:
         - override policies
 approval_rules:
   - name: Workflow .github/workflows/build.yml succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - ^go\.mod$
+          - ^go\.sum$
+          - ^(?:(?:[^/]*(?:/|$))*)(?:[^/]*)\.go$
+          - ^Dockerfile$
+          - ^\.github\/workflows\/build\.yml$
     requires:
       conditions:
         has_workflow_result:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+GITHUB_ACTIONS_WORKFLOWS=$(wildcard .github/workflows/*.yml)
 GO_FILES=$(wildcard cmd/*.go internal/*.go)
 
 check-policy.yml:
@@ -9,7 +10,7 @@ check-policy.yml:
 		( echo "No drift detected: .policy.yml is up-to-date." >&2; exit 0 ) || \
 		( echo "Drift detected: .policy.yml is out-of-date. Run \`make .policy.yml\` to update it, and then commit the result." >&2; exit 1 )
 
-.policy.yml: Makefile policy.yml $(GO_FILES)
+.policy.yml: Makefile policy.yml $(GITHUB_ACTIONS_WORKFLOWS) $(GO_FILES)
 	go run \
 	github.com/grafana/generate-policy-bot-config/cmd/generate-policy-bot-config \
 		--merge-with=policy.yml \


### PR DESCRIPTION
We have a path filter to avoid running the build on pushes to main where it's not needed. But we didn't have the same for PRs. That doesn't make all that much sense, so let's replicate it.
