### PR TITLE
fix(ci): push from release event too and handle multiple tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE: grafana/generate-policy-bot-config
-      PUSH_IMAGE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || '' }}
+      PUSH_IMAGE: ${{ (github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) || '' }}
 
     steps:
       - name: Checkout
@@ -92,8 +92,12 @@ jobs:
       - name: Extract platform-specific digests
         if: env.PUSH_IMAGE
         id: platform-digests
+        shell: bash
         run: |
-          REGISTRY_REF="${{ steps.calculate-metadata.outputs.tags }}"
+          declare -a TAGS
+          TAGS=(${{ steps.calculate-metadata.outputs.tags }})
+
+          REGISTRY_REF="${TAGS[0]}"
           BASE_REF="${REGISTRY_REF%%:*}"
 
           # Get digests for each platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     branches:
       - main
 
+  release:
+    types:
+      - published
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
we push latest and versioned tags here, need to handle that

also run `release-please` after releasing to update the new PR again
