### PR TITLE
chore(security): remediate workflow zizmor issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set Docker Buildx up
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -97,8 +99,9 @@ jobs:
           declare -a TAGS
           TAGS=(${{ steps.calculate-metadata.outputs.tags }})
 
-          REGISTRY_REF="${TAGS[0]}"
-          BASE_REF="${REGISTRY_REF%%:*}"
+          # Sanitize refs
+          REGISTRY_REF="$(echo "${TAGS[0]}" | sed 's/[^a-zA-Z0-9._\/:-]//g')"
+          BASE_REF="$(echo "${REGISTRY_REF%%:*}" | sed 's/[^a-zA-Z0-9._\/-]//g')"
 
           # Get digests for each platform
           MANIFEST_JSON="$(docker buildx imagetools inspect "${REGISTRY_REF}" --format '{{json .}}')"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go toolchain
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0


### PR DESCRIPTION
Fixes three issues identified by zizmor in workflows:

`build.yml`
1. "does not set persist-credentials: false" on actions/checkout (added it)
2. "steps.calculate-metadata.outputs.tags may expand into attacker-controllable code" (sanitized refs)

`lint.yaml`
1. "does not set persist-credentials: false" on actions/checkout (added it)

Trufflehog found no issues.