### PR TITLE
fix: generate extended and doublestar globs, and run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 on:
   pull_request:
@@ -36,7 +34,30 @@ on:
   merge_group:
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go toolchain
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Build
+        run: go build -v ./cmd/generate-policy-bot-config
+
   main:
+    needs: test
     permissions:
       attestations: write # for submitting SBOM and provenance attestations
       contents: write # for dependency submission API

--- a/internal/policybot.go
+++ b/internal/policybot.go
@@ -32,7 +32,7 @@ var SkippedOrSuccess = predicate.AllowedConclusions{"skipped", "success"}
 func regexpStringsFromGlobs(globs iter.Seq[string]) iter.Seq[string] {
 	return func(yield func(string) bool) {
 		for glob := range globs {
-			regexp := globre.RegexFromGlob(glob)
+			regexp := globre.RegexFromGlob(glob, globre.ExtendedSyntaxEnabled(true), globre.GlobStarEnabled(true))
 
 			if !yield(regexp) {
 				return
@@ -51,7 +51,7 @@ func RegexpsFromGlobs(globs []string) ([]common.Regexp, error) {
 	regexps := make([]common.Regexp, len(globs))
 
 	for i, glob := range globs {
-		regexp, err := common.NewRegexp(globre.RegexFromGlob(glob))
+		regexp, err := common.NewRegexp(globre.RegexFromGlob(glob, globre.ExtendedSyntaxEnabled(true), globre.GlobStarEnabled(true)))
 		if err != nil {
 			errors.Globs = append(errors.Globs, glob)
 			continue


### PR DESCRIPTION
At some point we updated to a new version of `go-globre` and this disabled extended and doublestar glob support by default. They're opted into by passing a couple of flags. That's what we do here.

This was caught by failing tests, but sadly we weren't actually running tests in CI. That's fixed now too, by adding a new job before the `build` job.
