### PR TITLE
fix: preserve config in input template verbatim

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -19,7 +19,7 @@ approval_rules:
         paths:
           - ^go\.mod$
           - ^go\.sum$
-          - ^(?:(?:[^/]*(?:/|$))*)(?:[^/]*)\.go$
+          - ^.*\/.*\.go$
           - ^Dockerfile$
           - ^\.github\/workflows\/build\.yml$
       file_not_deleted:
@@ -48,13 +48,13 @@ approval_rules:
             - .github/workflows/lint.yml
   - name: default to approval
   - name: override policies
-    options:
-      methods:
-        comments:
-          - 'policy bot: approve'
-          - 'policy-bot: approve'
-        github_review: false
     requires:
       count: 1
       permissions:
         - write
+    options:
+      methods:
+        comments:
+          - "policy bot: approve"
+          - "policy-bot: approve"
+        github_review: false

--- a/README.md
+++ b/README.md
@@ -147,6 +147,39 @@ policy:
 and so "some rule here", if triggered, will approve the group containing the
 workflows.
 
+### Your approval rules are copied through as they are
+
+The `approval_rules` of the merged configuration, and its `policy.disapproval`
+section, are copied into the output verbatim. Comments and key order survive, and
+so does anything Policy Bot understands but we don't.
+
+This matters because Policy Bot decides whether to apply a default by asking
+whether a field was set at all, and its own types can't be written back out
+without losing that distinction: the fields are tagged `omitempty`, so a field
+which was set to an empty value comes out looking unset. The case to know about
+is `methods.comments`:
+
+```yaml
+approval_rules:
+  - name: needs a review
+    requires:
+      count: 1
+    options:
+      methods:
+        comments: []
+        github_review: true
+```
+
+An empty `comments` list is the only way to say that no comment should count as
+approval. Were we to hand that back to Policy Bot through its own types, the
+field would vanish and Policy Bot would reinstate its `:+1:` and `👍` defaults —
+a rule which looks like it demands a review would quietly accept a thumbs-up
+instead.
+
+The `policy.approval` section is the exception: it has to be understood in order
+to be merged at all, so comments in it are still lost. Its contents are plain
+lists and rule names, which don't have this problem.
+
 ## Don't mind the regexes
 
 GitHub Actions uses `doublestar`-style globs for path filters. Policy Bot takes

--- a/cmd/generate-policy-bot-config/main.go
+++ b/cmd/generate-policy-bot-config/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/fs"
@@ -194,12 +195,28 @@ func (af *appFlags) abort() {
 
 // loadConfigFromReader reads a policy bot config from the given reader. This is
 // used to merge the generated config with an existing config.
-func loadConfigFromReader(r io.Reader) (policy.Config, error) {
-	var config policy.Config
-	decoder := yaml.NewDecoder(r)
-	if err := decoder.Decode(&config); err != nil {
-		return policy.Config{}, internal.ErrInvalidPolicyBotConfig{Err: err}
+//
+// The config is decoded twice. Once into policy-bot's own types, which we throw
+// away: it is there to reject a config that policy-bot couldn't load, which is
+// worth catching here rather than several steps later. And once into our own
+// type, which keeps the hand-written parts as raw YAML so that merging can't
+// change what they mean. See internal.Config.
+func loadConfigFromReader(r io.Reader) (internal.Config, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return internal.Config{}, fmt.Errorf("failed to read config: %w", err)
 	}
+
+	var validated policy.Config
+	if err := yaml.NewDecoder(bytes.NewReader(raw)).Decode(&validated); err != nil {
+		return internal.Config{}, internal.ErrInvalidPolicyBotConfig{Err: err}
+	}
+
+	var config internal.Config
+	if err := yaml.Unmarshal(raw, &config); err != nil {
+		return internal.Config{}, internal.ErrInvalidPolicyBotConfig{Err: err}
+	}
+
 	return config, nil
 }
 
@@ -215,7 +232,11 @@ func (af *appFlags) run(name string) error {
 	}
 
 	// Generate a policy bot config from them
-	config := workflows.PolicyBotConfig()
+	generated := workflows.PolicyBotConfig()
+
+	// The config to write out. With nothing to merge, the generated config goes
+	// out as it is; there is no hand-written config to preserve.
+	var config any = generated
 
 	// Merge the generated config with an existing config, if one was provided
 	if af.MergeConfig.Reader != nil {
@@ -225,11 +246,13 @@ func (af *appFlags) run(name string) error {
 			return err
 		}
 
-		config, err = internal.MergeConfigs(config, mergeConfig)
+		merged, err := internal.MergeConfigs(generated, mergeConfig)
 		if err != nil {
 			af.abort()
 			return fmt.Errorf("failed to merge generated config with existing config: %w", err)
 		}
+
+		config = merged
 	}
 
 	// Write the config to the output file

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,0 +1,109 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/approval"
+	"gopkg.in/yaml.v3"
+)
+
+// Config is a Policy Bot configuration which is about to be written out.
+//
+// It mirrors policy-bot's own `policy.Config`, except that the parts which can
+// come from a hand-written config — the approval rules and the disapproval
+// policy — are held as raw YAML nodes instead of policy-bot's types.
+//
+// This is because policy-bot's types are not safe to round-trip through YAML.
+// They use the difference between an absent field and an explicitly empty one
+// to decide whether to fall back to a default, but the fields are tagged
+// `omitempty`, so an empty value is indistinguishable from an absent one once
+// it has been encoded again. `methods.comments`, which lists the comments that
+// count as approval, is the clearest example: setting it to `[]` is the only
+// way to turn off approval by comment, but decoding and re-encoding it drops
+// the field, and Policy Bot restores its ":+1:" and "👍" defaults. Policy Bot
+// itself only ever reads configs, so this costs it nothing; we are the only
+// ones who write them.
+//
+// Nodes sidestep this: whatever somebody wrote by hand is copied through
+// untouched, and we don't have to track which of policy-bot's fields
+// distinguish "unset" from "empty". Comments and key order survive too.
+type Config struct {
+	Policy        Policy      `yaml:"policy,omitempty"`
+	ApprovalRules []yaml.Node `yaml:"approval_rules,omitempty"`
+}
+
+// Policy is the `policy` section of a Config.
+//
+// Approval keeps policy-bot's type because merging has to look inside it (see
+// mergeApprovals), and it is safe to round-trip: `approval.Policy` is a tree of
+// plain `interface{}` values, so it holds exactly what was written. Comments in
+// this section are still lost, which is a smaller problem than a rule quietly
+// changing meaning.
+//
+// Disapproval has to be a `yaml.Node` and not a `*yaml.Node`: yaml.v3 decodes
+// into either, but only encodes the former. A pointer is encoded as if it were
+// an ordinary struct, which produces `{}` and silently loses the policy. Use
+// IsZero to test whether one was set.
+type Policy struct {
+	Approval    approval.Policy `yaml:"approval,omitempty"`
+	Disapproval yaml.Node       `yaml:"disapproval,omitempty"`
+}
+
+// yamlNode converts a value into the YAML node that it marshals to, so that
+// generated config can be held in the same form as hand-written config.
+func yamlNode(value any) (yaml.Node, error) {
+	raw, err := yaml.Marshal(value)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("failed to marshal value: %w", err)
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return yaml.Node{}, fmt.Errorf("failed to unmarshal value: %w", err)
+	}
+
+	// Unmarshaling into a node always yields a document node wrapping the
+	// value we actually want.
+	if document.Kind == yaml.DocumentNode && len(document.Content) == 1 {
+		return *document.Content[0], nil
+	}
+
+	return document, nil
+}
+
+// approvalRuleNodes converts generated approval rules into raw YAML nodes, so
+// that they can sit in the same slice as the hand-written ones.
+func approvalRuleNodes(rules []*approval.Rule) ([]yaml.Node, error) {
+	nodes := make([]yaml.Node, 0, len(rules))
+
+	for _, rule := range rules {
+		node, err := yamlNode(rule)
+		if err != nil {
+			return nil, ErrInvalidPolicyBotConfig{
+				Err: fmt.Errorf("failed to convert generated approval rule %q: %w", rule.Name, err),
+			}
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes, nil
+}
+
+// approvalRuleName returns the value of an approval rule's `name` field, or the
+// empty string if it doesn't have one. Rules are held as nodes, so the name has
+// to be looked up rather than read from a struct field.
+func approvalRuleName(rule yaml.Node) string {
+	if rule.Kind != yaml.MappingNode {
+		return ""
+	}
+
+	// The children of a mapping node alternate between keys and values.
+	for i := 0; i+1 < len(rule.Content); i += 2 {
+		if rule.Content[i].Value == "name" {
+			return rule.Content[i+1].Value
+		}
+	}
+
+	return ""
+}

--- a/internal/merge.go
+++ b/internal/merge.go
@@ -6,19 +6,21 @@ import (
 
 	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/approval"
+	"gopkg.in/yaml.v3"
 )
 
 // checkApprovalRuleDupes checks for duplicate approval rule names. We don't
 // want to try to merge two rules with the same name. It's easier to reject
 // the merge and ask the user to choose a different name.
-func checkApprovalRuleDupes(rules []*approval.Rule) error {
+func checkApprovalRuleDupes(rules []yaml.Node) error {
 	rulesByName := make(map[string]struct{})
 	var duplicateNames []string
 	for _, rule := range rules {
-		if _, ok := rulesByName[rule.Name]; ok {
-			duplicateNames = append(duplicateNames, rule.Name)
+		name := approvalRuleName(rule)
+		if _, ok := rulesByName[name]; ok {
+			duplicateNames = append(duplicateNames, name)
 		}
-		rulesByName[rule.Name] = struct{}{}
+		rulesByName[name] = struct{}{}
 	}
 
 	if len(duplicateNames) > 0 {
@@ -92,38 +94,64 @@ func mergeApprovals(generatedApproval, mergeWithApproval approval.Policy) (appro
 	return generatedApproval, nil
 }
 
+// mergeDisapprovals picks the disapproval policy for the merged config. We
+// don't know how to sensibly merge two of them, so error if both sides have
+// one. In practice only the hand-written config ever does, because we don't
+// generate disapproval policies.
+func mergeDisapprovals(generated policy.Config, mergeWith Config) (yaml.Node, error) {
+	switch {
+	case generated.Policy.Disapproval != nil && !mergeWith.Policy.Disapproval.IsZero():
+		return yaml.Node{}, errMergeDisapproval{}
+
+	case generated.Policy.Disapproval != nil:
+		node, err := yamlNode(generated.Policy.Disapproval)
+		if err != nil {
+			return yaml.Node{}, ErrInvalidPolicyBotConfig{
+				Err: fmt.Errorf("failed to convert generated disapproval policy: %w", err),
+			}
+		}
+
+		return node, nil
+
+	default:
+		return mergeWith.Policy.Disapproval, nil
+	}
+}
+
 // MergeConfigs combines a generated config with an existing config using deep merging.
 // The existing config takes precedence over the generated config.
-func MergeConfigs(generated, mergeWith policy.Config) (policy.Config, error) {
+//
+// The hand-written config arrives as raw YAML nodes and is copied through
+// as-is, so that it means the same thing after the merge as it did before. See
+// Config for why that matters.
+func MergeConfigs(generated policy.Config, mergeWith Config) (Config, error) {
 	slog.Debug("merging user-provided policy with generated policy")
 
-	// Don't know how to sensibly merge disapprovals (and anyway, we don't
-	// generate one so one side should always be empty). error if both sides
-	// have disapprovals.
-	if generated.Policy.Disapproval != nil && mergeWith.Policy.Disapproval != nil {
-		return policy.Config{}, errMergeDisapproval{}
-	}
-
-	disapproval := generated.Policy.Disapproval
-	if disapproval == nil {
-		disapproval = mergeWith.Policy.Disapproval
+	disapproval, err := mergeDisapprovals(generated, mergeWith)
+	if err != nil {
+		return Config{}, err
 	}
 
 	approvals, err := mergeApprovals(generated.Policy.Approval, mergeWith.Policy.Approval)
 	if err != nil {
-		return policy.Config{}, err
+		return Config{}, err
 	}
 
-	merged := policy.Config{
-		Policy: policy.Policy{
+	generatedRules, err := approvalRuleNodes(generated.ApprovalRules)
+	if err != nil {
+		return Config{}, err
+	}
+
+	merged := Config{
+		Policy: Policy{
 			Approval:    approvals,
 			Disapproval: disapproval,
 		},
-		ApprovalRules: append(generated.ApprovalRules, mergeWith.ApprovalRules...),
+		ApprovalRules: append(generatedRules, mergeWith.ApprovalRules...),
 	}
 
 	if err := checkApprovalRuleDupes(merged.ApprovalRules); err != nil {
-		return policy.Config{}, err
+		return Config{}, err
 	}
 
 	slog.Debug(
@@ -135,7 +163,7 @@ func MergeConfigs(generated, mergeWith policy.Config) (policy.Config, error) {
 		"n_approval_policies_right", len(mergeWith.Policy.Approval),
 		"n_approval_policies_merged", len(merged.Policy.Approval),
 		"has_disapproval_left", generated.Policy.Disapproval != nil,
-		"has_disapproval_right", mergeWith.Policy.Disapproval != nil,
+		"has_disapproval_right", !mergeWith.Policy.Disapproval.IsZero(),
 	)
 
 	return merged, nil

--- a/internal/merge_test.go
+++ b/internal/merge_test.go
@@ -1,16 +1,45 @@
 package internal
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/approval"
-	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/policy/disapproval"
 	"github.com/palantir/policy-bot/policy/predicate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
+
+// mustParseConfig parses a hand-written config the way the tool does.
+func mustParseConfig(t *testing.T, config string) Config {
+	t.Helper()
+
+	var parsed Config
+	require.NoError(t, yaml.Unmarshal([]byte(config), &parsed))
+
+	return parsed
+}
+
+// mustParseRules parses the approval rules of a hand-written config.
+func mustParseRules(t *testing.T, config string) []yaml.Node {
+	t.Helper()
+
+	return mustParseConfig(t, config).ApprovalRules
+}
+
+// mustWriteConfig writes a config out the way the tool does, so that tests can
+// assert on what a user would end up with.
+func mustWriteConfig(t *testing.T, config Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteYamlToWriter(&buf, config))
+
+	return buf.String()
+}
 
 func TestMergeConfigs_MergeApprovalPolicies(t *testing.T) {
 	generated := policy.Config{
@@ -29,50 +58,36 @@ func TestMergeConfigs_MergeApprovalPolicies(t *testing.T) {
 			{Name: "rule2"},
 		},
 	}
-	mergeWith := policy.Config{
-		Policy: policy.Policy{
-			Approval: approval.Policy{
-				map[string][]string{
-					"or": {
-						"rule3",
-						"rule4",
-					},
-				},
-			},
-		},
-		ApprovalRules: []*approval.Rule{
-			{Name: "rule3"},
-			{Name: "rule4"},
-		},
-	}
-	expected := policy.Config{
-		Policy: policy.Policy{
-			Approval: approval.Policy{
-				map[string][]string{
-					"and": {
-						"rule1",
-						"rule2",
-					},
-				},
-				map[string][]string{
-					"or": {
-						"rule3",
-						"rule4",
-					},
-				},
-			},
-		},
-		ApprovalRules: []*approval.Rule{
-			{Name: "rule1"},
-			{Name: "rule2"},
-			{Name: "rule3"},
-			{Name: "rule4"},
-		},
-	}
+	mergeWith := mustParseConfig(t, `
+policy:
+  approval:
+    - or:
+        - rule3
+        - rule4
+
+approval_rules:
+  - name: rule3
+  - name: rule4
+`)
+
+	expected := `policy:
+  approval:
+    - and:
+        - rule1
+        - rule2
+    - or:
+        - rule3
+        - rule4
+approval_rules:
+  - name: rule1
+  - name: rule2
+  - name: rule3
+  - name: rule4
+`
 
 	merged, err := MergeConfigs(generated, mergeWith)
 	require.NoError(t, err)
-	assert.Equal(t, expected, merged)
+	assert.Equal(t, expected, mustWriteConfig(t, merged))
 }
 
 func TestMergeConfigs_MergeApprovalPoliciesWithGeneratedApproval(t *testing.T) {
@@ -96,59 +111,129 @@ func TestMergeConfigs_MergeApprovalPoliciesWithGeneratedApproval(t *testing.T) {
 			{Name: "rule2"},
 		},
 	}
-	mergeWith := policy.Config{
-		Policy: policy.Policy{
-			Approval: approval.Policy{
-				map[string]interface{}{
-					"or": []interface{}{
-						"MERGE_WITH_GENERATED",
-						"rule3",
-					},
-				},
-				map[string]interface{}{
-					"and": []interface{}{
-						"rule4",
-					},
-				},
-			},
-		},
-		ApprovalRules: []*approval.Rule{
-			{Name: "rule3"},
-			{Name: "rule4"},
-		},
-	}
-	expected := policy.Config{
-		Policy: policy.Policy{
-			Approval: approval.Policy{
-				map[string]interface{}{
-					"or": []interface{}{
-						map[string]interface{}{
-							"and": []interface{}{
-								"rule1",
-								"rule2",
-							},
-						},
-						"rule3",
-					},
-				},
-				map[string]interface{}{
-					"and": []interface{}{
-						"rule4",
-					},
-				},
-			},
-		},
-		ApprovalRules: []*approval.Rule{
-			{Name: "rule1"},
-			{Name: "rule2"},
-			{Name: "rule3"},
-			{Name: "rule4"},
-		},
-	}
+	mergeWith := mustParseConfig(t, `
+policy:
+  approval:
+    - or:
+        - MERGE_WITH_GENERATED
+        - rule3
+    - and:
+        - rule4
+
+approval_rules:
+  - name: rule3
+  - name: rule4
+`)
+
+	expected := `policy:
+  approval:
+    - or:
+        - and:
+            - rule1
+            - rule2
+        - rule3
+    - and:
+        - rule4
+approval_rules:
+  - name: rule1
+  - name: rule2
+  - name: rule3
+  - name: rule4
+`
 
 	merged, err := MergeConfigs(generated, mergeWith)
 	require.NoError(t, err)
-	assert.Equal(t, expected, merged)
+	assert.Equal(t, expected, mustWriteConfig(t, merged))
+}
+
+// TestMergeConfigs_PreservesExplicitlyEmptyValues checks that a field which is
+// set to an explicitly empty value survives the merge. Policy Bot's own types
+// can't express this — they tag these fields `omitempty`, so encoding them again
+// drops them — which is why hand-written config is kept as raw YAML.
+//
+// `methods.comments` is the case that matters in practice: an empty list is the
+// only way to say that no comment should count as approval, and losing it means
+// Policy Bot silently reinstates its ":+1:" and "👍" defaults.
+func TestMergeConfigs_PreservesExplicitlyEmptyValues(t *testing.T) {
+	generated := policy.Config{
+		ApprovalRules: []*approval.Rule{
+			{Name: "rule1"},
+		},
+	}
+	mergeWith := mustParseConfig(t, `
+approval_rules:
+  - name: needs a review from the team
+    requires:
+      count: 1
+      teams:
+        - grafana/some-team
+    options:
+      methods:
+        comments: []
+        github_review: true
+`)
+
+	expected := `approval_rules:
+  - name: rule1
+  - name: needs a review from the team
+    requires:
+      count: 1
+      teams:
+        - grafana/some-team
+    options:
+      methods:
+        comments: []
+        github_review: true
+`
+
+	merged, err := MergeConfigs(generated, mergeWith)
+	require.NoError(t, err)
+	assert.Equal(t, expected, mustWriteConfig(t, merged))
+}
+
+// TestMergeConfigs_PreservesCommentsAndFormatting checks that hand-written rules
+// come out the way they went in, rather than reformatted into the shape of
+// Policy Bot's structs. Comments are worth keeping because they are often the
+// only explanation of why a rule exists.
+func TestMergeConfigs_PreservesCommentsAndFormatting(t *testing.T) {
+	generated := policy.Config{
+		ApprovalRules: []*approval.Rule{
+			{Name: "rule1"},
+		},
+	}
+	mergeWith := mustParseConfig(t, `
+approval_rules:
+  # Anybody with write access can override the policies by commenting.
+  - name: override policies
+    requires:
+      count: 1
+      permissions:
+        - write
+    options:
+      methods:
+        comments:
+          - "policy bot: approve"
+        github_review: false
+`)
+
+	expected := `approval_rules:
+  - name: rule1
+  # Anybody with write access can override the policies by commenting.
+  - name: override policies
+    requires:
+      count: 1
+      permissions:
+        - write
+    options:
+      methods:
+        comments:
+          - "policy bot: approve"
+        github_review: false
+`
+
+	merged, err := MergeConfigs(generated, mergeWith)
+	require.NoError(t, err)
+	assert.Equal(t, expected, mustWriteConfig(t, merged))
 }
 
 func TestMergeConfigs_MergeWithDisapprovalInmergeWithConfig(t *testing.T) {
@@ -158,68 +243,49 @@ func TestMergeConfigs_MergeWithDisapprovalInmergeWithConfig(t *testing.T) {
 				map[string][]string{
 					"and": {
 						"rule1",
-						"rule2",
 					},
 				},
 			},
 		},
 		ApprovalRules: []*approval.Rule{
 			{Name: "rule1"},
-			{Name: "rule2"},
 		},
 	}
-	mergeWith := policy.Config{
-		Policy: policy.Policy{
-			Disapproval: &disapproval.Policy{
-				Predicates: predicate.Predicates{
-					ChangedFiles: &predicate.ChangedFiles{
-						Paths: mustRegexpsFromGlobs(t, []string{"*.go"}),
-					},
-				},
-				Options: disapproval.Options{
-					Methods: disapproval.Methods{
-						Disapprove: &common.Methods{
-							Comments: []string{"Disapproved"},
-						},
-					},
-				},
-			},
-		},
-	}
-	expected := policy.Config{
-		Policy: policy.Policy{
-			Approval: approval.Policy{
-				map[string][]string{
-					"and": {
-						"rule1",
-						"rule2",
-					},
-				},
-			},
-			Disapproval: &disapproval.Policy{
-				Predicates: predicate.Predicates{
-					ChangedFiles: &predicate.ChangedFiles{
-						Paths: mustRegexpsFromGlobs(t, []string{"*.go"}),
-					},
-				},
-				Options: disapproval.Options{
-					Methods: disapproval.Methods{
-						Disapprove: &common.Methods{
-							Comments: []string{"Disapproved"},
-						},
-					},
-				},
-			},
-		},
-		ApprovalRules: []*approval.Rule{
-			{Name: "rule1"},
-			{Name: "rule2"},
-		},
-	}
+	mergeWith := mustParseConfig(t, `
+policy:
+  disapproval:
+    if:
+      changed_files:
+        paths:
+          - \.go$
+    options:
+      methods:
+        disapprove:
+          comments:
+            - Disapproved
+`)
+
+	expected := `policy:
+  approval:
+    - and:
+        - rule1
+  disapproval:
+    if:
+      changed_files:
+        paths:
+          - \.go$
+    options:
+      methods:
+        disapprove:
+          comments:
+            - Disapproved
+approval_rules:
+  - name: rule1
+`
 
 	merged, err := MergeConfigs(generated, mergeWith)
 	require.NoError(t, err)
-	assert.Equal(t, expected, merged)
+	assert.Equal(t, expected, mustWriteConfig(t, merged))
 }
 
 func TestMergeConfigs_ErrorOnBothConfigsHavingDisapproval(t *testing.T) {
@@ -234,61 +300,102 @@ func TestMergeConfigs_ErrorOnBothConfigsHavingDisapproval(t *testing.T) {
 			},
 		},
 	}
-	mergeWith := policy.Config{
-		Policy: policy.Policy{
-			Disapproval: &disapproval.Policy{
-				Predicates: predicate.Predicates{
-					ChangedFiles: &predicate.ChangedFiles{
-						Paths: mustRegexpsFromGlobs(t, []string{"*.js"}),
-					},
-				},
-			},
-		},
-	}
+	mergeWith := mustParseConfig(t, `
+policy:
+  disapproval:
+    if:
+      changed_files:
+        paths:
+          - \.js$
+`)
 
 	_, err := MergeConfigs(generated, mergeWith)
 	require.ErrorIs(t, err, errMergeDisapproval{})
 }
 
+// TestMergeConfigs_GeneratedDisapprovalIsKept covers the case where only the
+// generated config has a disapproval policy. We don't generate one today, so
+// this is here to make sure it wouldn't be dropped if we ever did.
+func TestMergeConfigs_GeneratedDisapprovalIsKept(t *testing.T) {
+	generated := policy.Config{
+		Policy: policy.Policy{
+			Disapproval: &disapproval.Policy{
+				Predicates: predicate.Predicates{
+					ChangedFiles: &predicate.ChangedFiles{
+						Paths: mustRegexpsFromGlobs(t, []string{"*.go"}),
+					},
+				},
+			},
+		},
+	}
+	mergeWith := mustParseConfig(t, `
+approval_rules:
+  - name: rule1
+`)
+
+	merged, err := MergeConfigs(generated, mergeWith)
+	require.NoError(t, err)
+
+	require.False(t, merged.Policy.Disapproval.IsZero())
+	assert.Contains(t, mustWriteConfig(t, merged), "disapproval:")
+}
+
 func TestCheckApprovalRuleDupes(t *testing.T) {
 	tests := []struct {
 		name     string
-		rules    []*approval.Rule
+		rules    string
 		errNames []string
 	}{
 		{
 			name: "No duplicates",
-			rules: []*approval.Rule{
-				{Name: "rule1"},
-				{Name: "rule2"},
-				{Name: "rule3"},
-			},
+			rules: `
+approval_rules:
+  - name: rule1
+  - name: rule2
+  - name: rule3
+`,
 		},
 		{
 			name: "One duplicate",
-			rules: []*approval.Rule{
-				{Name: "rule1"},
-				{Name: "rule2"},
-				{Name: "rule1"},
-			},
+			rules: `
+approval_rules:
+  - name: rule1
+  - name: rule2
+  - name: rule1
+`,
 			errNames: []string{"rule1"},
 		},
 		{
 			name: "Multiple duplicates",
-			rules: []*approval.Rule{
-				{Name: "rule1"},
-				{Name: "rule2"},
-				{Name: "rule1"},
-				{Name: "rule3"},
-				{Name: "rule2"},
-			},
+			rules: `
+approval_rules:
+  - name: rule1
+  - name: rule2
+  - name: rule1
+  - name: rule3
+  - name: rule2
+`,
 			errNames: []string{"rule1", "rule2"},
+		},
+		{
+			name: "Rules with fields in any order",
+			rules: `
+approval_rules:
+  - requires:
+      count: 1
+    name: rule1
+  - name: rule2
+  - name: rule1
+    requires:
+      count: 2
+`,
+			errNames: []string{"rule1"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := checkApprovalRuleDupes(tt.rules)
+			err := checkApprovalRuleDupes(mustParseRules(t, tt.rules))
 
 			if len(tt.errNames) == 0 {
 				require.NoError(t, err)
@@ -299,6 +406,50 @@ func TestCheckApprovalRuleDupes(t *testing.T) {
 			var dupeErr errMergeDuplicateApprovalRules
 			require.ErrorAs(t, err, &dupeErr)
 			assert.ElementsMatch(t, tt.errNames, dupeErr.names)
+		})
+	}
+}
+
+func TestApprovalRuleName(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     string
+		expected string
+	}{
+		{
+			name:     "Name first",
+			rule:     "name: rule1\nrequires:\n  count: 1\n",
+			expected: "rule1",
+		},
+		{
+			name:     "Name last",
+			rule:     "requires:\n  count: 1\nname: rule1\n",
+			expected: "rule1",
+		},
+		{
+			name:     "No name",
+			rule:     "requires:\n  count: 1\n",
+			expected: "",
+		},
+		{
+			name:     "Not a mapping",
+			rule:     "- rule1\n",
+			expected: "",
+		},
+		{
+			name:     "Nested name is not the rule name",
+			rule:     "requires:\n  name: not-the-rule-name\n",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var node yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(tt.rule), &node))
+			require.Equal(t, yaml.DocumentNode, node.Kind)
+
+			assert.Equal(t, tt.expected, approvalRuleName(*node.Content[0]))
 		})
 	}
 }


### PR DESCRIPTION
The current code uses policy-bot's types to load the template: this has the nice effect of validating the input as a policy-bot configuration file. On the other had it has the bad side-effect that some parts of the configuration are discarded because some fields are annotated with "omitempty".

In order to preserve that part of the input, don't use the policy-bot types but instead process the YAML using the yaml package instead.

This change is noisy because of the changes to the types.

Update the README to reflect this and add tests to assert this case.